### PR TITLE
avoid a rustc bug

### DIFF
--- a/src/docker/docker_command.rs
+++ b/src/docker/docker_command.rs
@@ -25,7 +25,7 @@ impl<'a> DockerCommand<'a> {
         cmd(
             "docker",
             self.arguments.iter().map(|argument| {
-                let argument_str: &'a str = argument.borrow();
+                let argument_str: &str = argument.borrow();
                 OsStr::new(argument_str)
             }),
         )


### PR DESCRIPTION
Hi,

https://github.com/rust-lang/rust/pull/98835 fixes a rustc bug that makes it incorrectly accepts the following code:
```rust
fn test<'a: 'a>() { // 'a is longer than the entire function body
    let f = |_: &'a str| {}; // expects an argument that lives as long as 'a
    f(&String::new()); // the passed reference is shorter that `'a`
}
```

The crater run found that `dkr` relies on this bug. I'm not sure when this change reaches stable, if ever, but it's better to not rely on such a bug. This PR tries to fix this.

If you have an opinion on this change, please let me know here or  by commenting on the PR.

You can install and test the toolchain locally by running the command: `rustup-toolchain-install-master cb1f7c96119295882e08b09b4bd01051669c071b`